### PR TITLE
More benches

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,4 +7,5 @@ members = [
 
 [profile.release]
 lto = true
+panic = "abort"
 codegen-units = 1

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,9 @@
 .PHONY: build-node-%
 build-node-%: export PAIR = $(subst +, ,$(subst build-node-,,$@))
 build-node-%:
-	cargo build --package secp256k1-node --target $(firstword $(PAIR)) --release
+	cargo build --package secp256k1-node --target $(firstword $(PAIR)) -Z build-std=panic_abort,std --release
 	cp -f target/$(firstword $(PAIR))/release/libsecp256k1_node.so lib/secp256k1-$(lastword $(PAIR)).so
+	strip lib/secp256k1-$(lastword $(PAIR)).so
 
 .PHONY: build-node-debug
 build-node-debug:

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ build-wasm-debug:
 
 .PHONY: clean
 clean:
-	rm -rf lib/secp256k1* target node_modules tests/browser
+	rm -rf benches/node_modules lib/secp256k1* target node_modules tests/browser
 
 .PHONY: format
 format:

--- a/benches/index.js
+++ b/benches/index.js
@@ -5,7 +5,17 @@ import * as cryptocoinjs_secp256k1 from "./cryptocoinjs_secp256k1.js";
 import noble_secp256k1 from "./noble_secp256k1.js";
 import { fecdsa, fpoints, fprivates } from "./fixtures.js";
 
+// import { loadAddon as _loadAddon } from "../lib/addon.js";
+// function loadAddon(location) {
+//   const path = new URL(location, import.meta.url).pathname;
+//   return _loadAddon(path);
+// }
+
 const modules = [
+  // {
+  //   name: "tiny-secp256k1 (Rust addon, N-API, opt-level-3)",
+  //   secp256k1: loadAddon("./opt-level-3.so"),
+  // },
   {
     name: "tiny-secp256k1 (Rust addon, N-API)",
     secp256k1: tiny_secp256k1.__addon,

--- a/benches/noble_secp256k1.js
+++ b/benches/noble_secp256k1.js
@@ -1,0 +1,17 @@
+import secp256k1 from "noble-secp256k1";
+
+export default {
+  // isPoint
+  // isPointCompressed
+  // isPrivate
+  // pointAdd
+  // pointAddScalar
+  // pointCompress
+  pointFromScalar: secp256k1.getPublicKey,
+  // pointMultiply
+  // privateAdd
+  // privateSub
+  sign: secp256k1.sign,
+  // signWithEntropy
+  // verify: (h, Q, signature) => secp256k1.verify(signature, h, Q),
+};

--- a/benches/package-lock.json
+++ b/benches/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.0.0",
       "license": "MIT",
       "devDependencies": {
-        "secp256k1": "^4.0.2",
+        "noble-secp256k1": "^1.1.2",
+        "secp256k1": "=4.0.2",
         "tiny-secp256k1": "=1.1.6"
       }
     },
@@ -160,6 +161,12 @@
       "version": "2.14.2",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
       "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
+      "dev": true
+    },
+    "node_modules/noble-secp256k1": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/noble-secp256k1/-/noble-secp256k1-1.1.2.tgz",
+      "integrity": "sha512-+fW9Vt7ev0aT+esL8tVsH79GiDB0b8Nzk9cgwPKXoG1rKJjaA7Phg2VzxV541qdu/V1bG/y8xA0nJBu1QvBmTg==",
       "dev": true
     },
     "node_modules/node-addon-api": {
@@ -429,6 +436,12 @@
       "version": "2.14.2",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
       "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
+      "dev": true
+    },
+    "noble-secp256k1": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/noble-secp256k1/-/noble-secp256k1-1.1.2.tgz",
+      "integrity": "sha512-+fW9Vt7ev0aT+esL8tVsH79GiDB0b8Nzk9cgwPKXoG1rKJjaA7Phg2VzxV541qdu/V1bG/y8xA0nJBu1QvBmTg==",
       "dev": true
     },
     "node-addon-api": {

--- a/benches/package.json
+++ b/benches/package.json
@@ -9,6 +9,7 @@
     "start": "node --experimental-json-modules index.js"
   },
   "devDependencies": {
+    "noble-secp256k1": "=1.1.2",
     "secp256k1": "=4.0.2",
     "tiny-secp256k1": "=1.1.6"
   }

--- a/lib/addon.js
+++ b/lib/addon.js
@@ -28,7 +28,7 @@ function getLocalBuildLibLocation(mode) {
   return new URL(path, import.meta.url).pathname;
 }
 
-function loadAddon(location) {
+export function loadAddon(location) {
   try {
     const module = { exports: { throwError, generateSeed } };
     process.dlopen(module, location);


### PR DESCRIPTION
Added benches to [paulmillr/noble-secp256k1](https://github.com/paulmillr/noble-secp256k1). Only `pointFromScalar` / `sign`.

```
====================================================================================================
Benchmarking function: pointFromScalar
----------------------------------------------------------------------------------------------------
tiny-secp256k1 (rust addon): 41.65 us/op (24011.22 op/s), ±11.57 %
tiny-secp256k1 (wasm): 277.12 us/op (3608.57 op/s), ±3.08 %
tiny-secp256k1@1.1.6 (C++ addon, NAN/V8): 30.06 us/op (33265.69 op/s), ±3.67 %
tiny-secp256k1@1.1.6 (elliptic): 504.15 us/op (1983.52 op/s), ±3.42 %
secp256k1@4.0.2 (C++ addon, N-API): 31.23 us/op (32022.68 op/s), ±4.23 %
secp256k1@4.0.2 (elliptic): 503.60 us/op (1985.69 op/s), ±3.61 %
noble-secp256k1@1.1.2 (BigInt): 368.69 us/op (2712.29 op/s), ±3.97 %
----------------------------------------------------------------------------------------------------
Fastest: tiny-secp256k1@1.1.6 (C++ addon, NAN/V8)
====================================================================================================
Benchmarking function: sign
----------------------------------------------------------------------------------------------------
tiny-secp256k1 (rust addon): 61.30 us/op (16313.73 op/s), ±3.15 %
tiny-secp256k1 (wasm): 463.98 us/op (2155.26 op/s), ±0.13 %
tiny-secp256k1@1.1.6 (C++ addon, NAN/V8): 49.29 us/op (20286.89 op/s), ±2.50 %
tiny-secp256k1@1.1.6 (elliptic): 857.85 us/op (1165.71 op/s), ±1.47 %
secp256k1@4.0.2 (C++ addon, N-API): 51.12 us/op (19560.30 op/s), ±2.78 %
secp256k1@4.0.2 (elliptic): 889.37 us/op (1124.40 op/s), ±0.30 %
noble-secp256k1@1.1.2 (BigInt): 562.15 us/op (1778.88 op/s), ±0.58 %
----------------------------------------------------------------------------------------------------
Fastest: tiny-secp256k1@1.1.6 (C++ addon, NAN/V8)
====================================================================================================
```

@paulmillr maybe this result will be interesting for you. My CPU: i5-8250U.
If `verify` will be able to accept raw signature (64 bytes `r|s`) I would able to add it to benchmark too.